### PR TITLE
Fix boy group site loading on iPhone

### DIFF
--- a/bg/main.js
+++ b/bg/main.js
@@ -9609,13 +9609,33 @@ var app = (function () {
         ((c = "webkitHidden"), (d = "webkitvisibilitychange")),
       void 0 === document.addEventListener ||
         void 0 === c ||
-        document.addEventListener(
-          d,
-          function () {
-            document[c] || a === x(Vt.startDate) || location.reload(!0);
-          },
-          !1
-        );
+        (function () {
+          var isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
+          var lastReloadTs = 0;
+          function maybeReloadOnVisible() {
+            try {
+              var now = Date.now();
+              if (now - lastReloadTs < 1500) return; // throttle
+              if (!document[c] && a !== x(Vt.startDate)) {
+                // Avoid aggressive reloads on iOS Safari which can fire repeatedly
+                if (isIOS) return;
+                lastReloadTs = now;
+                location.reload(!0);
+              }
+            } catch (e) {}
+          }
+          document.addEventListener(d, maybeReloadOnVisible, !1);
+          // Also handle bfcache restores safely
+          window.addEventListener(
+            "pageshow",
+            function (evt) {
+              if (evt && evt.persisted) {
+                maybeReloadOnVisible();
+              }
+            },
+            !1
+          );
+        })();
     let h,
       f,
       m = 0;


### PR DESCRIPTION
## What’s in this PR?
- [ ] New songs added to `music-stuff/songs.js`
- [ ] Songs moved to `music-stuff/previous_songs.js`
- [x] Docs/other (Bug fix for iOS site loading)

## Checklist
- [ ] Each entry has both `url` and `answer`
- [ ] If `answer` starts with a number, it has a leading space
- [ ] I ran `python music-stuff/tools/validate_songs.py` locally (optional)
- [ ] No duplicate URLs or answers

## Notes for reviewers
This PR fixes an issue where the "boy group" version of the site failed to load on iOS Safari (e.g., iPhone 14 Pro).

The problem was an aggressive `visibilitychange` auto-reload loop on iOS. This change adds an iOS-specific guard and throttling to the reload logic in `bg/main.js` and also handles `pageshow` events to prevent issues with bfcache restores. This should prevent the site from getting stuck in a reload loop and allow it to load correctly on iOS devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-5dc5d883-f793-4544-a802-f242bfe17b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5dc5d883-f793-4544-a802-f242bfe17b29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

